### PR TITLE
Update #21 - Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: java
 jdk:
   - openjdk16
 
-branches:
-  only:
-    - main
-
 # Travis CI Server's Home
 cache:
   directories:


### PR DESCRIPTION
기존 메인에서만 작동하도록 하는 세팅 자동 X

master? main? 으로 인한 오류인지 확인 불가

트레비스 사이트를 통해 메인 브렌치에서만 작동하도록 설정예정

이 파일에서는 해당 설정 부분 생략